### PR TITLE
feat: add lambda function name to log payload

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -121,10 +121,12 @@ async fn run_extension(config: Arc<Config>, metrics: &mut ExtensionMetrics) -> R
     // Set up telemetry components
     
     // Create aggregator
+    let function_name = env::var("AWS_LAMBDA_FUNCTION_NAME").unwrap_or_else(|_| "unknown".to_string());
     let aggregator = Arc::new(tokio::sync::Mutex::new(
         telemetry::TelemetryAggregator::new(
             config.max_buffer_size_bytes(),
             100, // max batch entries
+            function_name,
         )
     ));
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -26,15 +26,17 @@ pub struct TelemetryAggregator {
     buffer: Vec<u8>,
     max_content_size_bytes: usize,
     max_batch_entries_size: usize,
+    function_name: String,
 }
 
 impl TelemetryAggregator {
-    pub fn new(max_content_size_bytes: usize, max_batch_entries_size: usize) -> Self {
+    pub fn new(max_content_size_bytes: usize, max_batch_entries_size: usize, function_name: String) -> Self {
         Self {
             messages: VecDeque::new(),
             buffer: Vec::with_capacity(max_content_size_bytes),
             max_content_size_bytes,
             max_batch_entries_size,
+            function_name,
         }
     }
 
@@ -45,7 +47,8 @@ impl TelemetryAggregator {
             let mut event_json = serde_json::json!({
                 "_timestamp": event.time.timestamp_micros(),
                 "record": event.record,
-                "type": event.event_type
+                "type": event.event_type,
+                "function_name": self.function_name
             });
             
             // Add requestId if present
@@ -261,7 +264,7 @@ mod tests {
     
     #[test]
     fn test_telemetry_aggregator() {
-        let mut aggregator = TelemetryAggregator::new(1024, 10);
+        let mut aggregator = TelemetryAggregator::new(1024, 10, "test-function".to_string());
         
         let events = vec![
             TelemetryEvent {


### PR DESCRIPTION
This PR adds the AWS Lambda function name to the logs sent to OpenObserve. This allows users to distinguish logs coming from different Lambda functions when they are aggregated in the same OpenObserve stream.

The function name is retrieved from the AWS_LAMBDA_FUNCTION_NAME environment variable, which is automatically set by the AWS Lambda runtime.

Changes
src/telemetry.rs:
Updated 
TelemetryAggregator
 struct to include function_name.
Updated TelemetryAggregator::new to accept function_name.
Modified 
add_batch
 to inject function_name into the JSON payload sent to OpenObserve.
src/main.rs:
Read AWS_LAMBDA_FUNCTION_NAME from the environment.
Pass the function name when initializing 
TelemetryAggregator